### PR TITLE
Trimmomatic changes

### DIFF
--- a/Trinity
+++ b/Trinity
@@ -29,6 +29,25 @@ use HTC::GridRunner;
 
 open (STDERR, ">&STDOUT");  ## capturing stderr and stdout in a single stdout stream
 
+#directory defnintions
+my $ROOTDIR = "$FindBin::RealBin";
+my $UTILDIR = "$ROOTDIR/util";
+my $MISCDIR = "$UTILDIR/misc";
+my $INCHWORM_DIR = "$ROOTDIR/Inchworm/bin/";
+my $CHRYSALIS_DIR = "$ROOTDIR/Chrysalis";
+my $BUTTERFLY_DIR = "$ROOTDIR/Butterfly";
+my $JELLYFISH_DIR = "$ROOTDIR/trinity-plugins/jellyfish";
+my $FASTOOL_DIR = "$ROOTDIR/trinity-plugins/fastool";
+my $COLLECTL_DIR = "$ROOTDIR/trinity-plugins/collectl/bin";
+my $COREUTILS_DIR = "$ROOTDIR/trinity-plugins/coreutils/bin";
+my $PARAFLY = "$ROOTDIR/trinity-plugins/parafly/bin/ParaFly";
+my $TRIMMOMATIC = "$ROOTDIR/trinity-plugins/Trimmomatic/trimmomatic.jar";
+my $TRIMMOMATIC_DIR = "$ROOTDIR/trinity-plugins/Trimmomatic";
+
+#&version_check();
+
+
+
 # Site specific setup
 
 my $KMER_SIZE = 25;
@@ -173,7 +192,7 @@ my $NO_PARALLEL_IWORM = 0;
 
 ## Quality trimming params
 my $RUN_TRIMMOMATIC_FLAG = 0;
-my $trimmomatic_quality_trim_params = "LEADING:5 TRAILING:5 MINLEN:36";
+my $trimmomatic_quality_trim_params = "ILLUMINACLIP:$TRIMMOMATIC_DIR/adapters/TruSeq3-PE.fa:2:30:10 SLIDINGWINDOW:4:5 LEADING:5 TRAILING:5 MINLEN:25";
 
 ## Normalize reads
 my $NORMALIZE_READS_FLAG = 0;
@@ -474,20 +493,6 @@ _ADVANCEDUSAGE_
  ;
 
 
-my $ROOTDIR = "$FindBin::RealBin";
-my $UTILDIR = "$ROOTDIR/util";
-my $MISCDIR = "$UTILDIR/misc";
-my $INCHWORM_DIR = "$ROOTDIR/Inchworm/bin/";
-my $CHRYSALIS_DIR = "$ROOTDIR/Chrysalis";
-my $BUTTERFLY_DIR = "$ROOTDIR/Butterfly";
-my $JELLYFISH_DIR = "$ROOTDIR/trinity-plugins/jellyfish";
-my $FASTOOL_DIR = "$ROOTDIR/trinity-plugins/fastool";
-my $COLLECTL_DIR = "$ROOTDIR/trinity-plugins/collectl/bin";
-my $COREUTILS_DIR = "$ROOTDIR/trinity-plugins/coreutils/bin";
-my $PARAFLY = "$ROOTDIR/trinity-plugins/parafly/bin/ParaFly";
-my $TRIMMOMATIC = "$ROOTDIR/trinity-plugins/Trimmomatic/trimmomatic.jar";
-
-#&version_check();
 
 my $usage = $basic_usage . $usage_synopsis;
 


### PR DESCRIPTION
changes: 

- need directory definitions for trimmomatic quality params, so moved this up to top of file, not sure if there are any performance implications of this.  
- lower MINLEN to 25. This makes sense given kmer size. Consider changing this once variable kmer selection is enabled.
- Add adapter trimming by default. This should have been included a long time ago as I think people are forgetting to do this independent of Trinity run.. Right now, the adapters only cover truseq library preps as these are the most common, but could modify the adapter file to include older preps corner cases.. Adapter searching is not time consuming, so this might be worth while 
- added SLIDINGWINDOW trimming, as this will capture and trim low qual areas internal.