### PR TITLE
Allow Trinity to be run when symlinked

### DIFF
--- a/Trinity
+++ b/Trinity
@@ -6,7 +6,7 @@ use threads;
 no strict qw(subs refs);
 
 use FindBin;
-use lib ("$FindBin::Bin/PerlLib");
+use lib ("$FindBin::RealBin/PerlLib");
 use File::Basename;
 use Time::localtime;
 use Cwd;


### PR DESCRIPTION
Is it intentional to let `Trinity` not runnable when symlinked?