### PR TITLE
remove default dispersion parameter for unreplicated designs in edgeR

### DIFF
--- a/Analysis/DifferentialExpression/run_DE_analysis.pl
+++ b/Analysis/DifferentialExpression/run_DE_analysis.pl
@@ -54,7 +54,7 @@ my $usage = <<__EOUSAGE__;
 #  ## EdgeR-related parameters
 #  ## (no biological replicates)
 #
-#  --dispersion <float>            edgeR dispersion value set to 0 for poisson (sometimes breaks...)
+#  --dispersion <float>            edgeR dispersion value. Set to 0 for poisson (sometimes breaks...)
 #  
 #  see edgeR user manual for suggestions
 #  http://www.bioconductor.org/packages/release/bioc/html/edgeR.html

--- a/Analysis/DifferentialExpression/run_DE_analysis.pl
+++ b/Analysis/DifferentialExpression/run_DE_analysis.pl
@@ -54,8 +54,9 @@ my $usage = <<__EOUSAGE__;
 #  ## EdgeR-related parameters
 #  ## (no biological replicates)
 #
-#  --dispersion <float>            edgeR dispersion value (default: 0.1)   set to 0 for poisson (sometimes breaks...)
-#
+#  --dispersion <float>            edgeR dispersion value set to 0 for poisson (sometimes breaks...)
+#  
+#  see edgeR user manual for suggestions
 #  http://www.bioconductor.org/packages/release/bioc/html/edgeR.html
 #
 ###############################################################################################
@@ -87,7 +88,7 @@ my $samples_file;
 my $min_rowSum_counts = 2;
 my $help_flag;
 my $output_dir;
-my $dispersion = 0.1;
+my $dispersion;
 my $contrasts_file;
 
 my $reference_sample;
@@ -392,6 +393,9 @@ sub run_edgeR_sample_pair {
         print $ofh "exp_study = estimateTagwiseDisp(exp_study)\n";
         print $ofh "et = exactTest(exp_study)\n";
     }
+    elsif (!$dispersion) {
+	die "Error, cannot calculate dispersions due to lack of replicates. Specify a dispersion parameter --dispersion <float>. See help for details\n";
+    }
     else {
         print $ofh "et = exactTest(exp_study, dispersion=$dispersion)\n";
     }
@@ -445,7 +449,7 @@ sub run_DESeq_sample_pair {
     }
     
 
-    ## write R-script to run edgeR
+    ## write R-script to run DESeq
     open (my $ofh, ">$Rscript_name") or die "Error, cannot write to $Rscript_name";
     
     print $ofh "library(DESeq)\n";
@@ -543,7 +547,7 @@ sub run_DESeq2_sample_pair {
     }
     
 
-    ## write R-script to run edgeR
+    ## write R-script to run DESeq2
     open (my $ofh, ">$Rscript_name") or die "Error, cannot write to $Rscript_name";
     
     print $ofh "library(DESeq2)\n";


### PR DESCRIPTION
In my experience, when people use `run_DE_analysis.pl` to run `edgeR` on an unreplicated design they often do not notice that an arbitrary dispersion parameter is being supplied by `run_DE_analysis.pl` by default. I think part of the confusion comes because `run_DE_analysis` calls `DESeq` with `method='blind'` for unreplicated designs, and so some users think that something similar happens when specifying `--method edgeR`.

I think it is most transparent to have `run_DE_analysis.pl` die (with a message to tell the user that they need to specify `--dispersion <float>`) when called with `--method edgeR` on an unreplicated design .

Hopefully they then realize that simply using 0.1 is dubious at best.