### PR TITLE
Analysis/DifferentialExpression/run_DE_analysis.pl is not using exactTest correctly

### DIFF
--- a/Analysis/DifferentialExpression/run_DE_analysis.pl
+++ b/Analysis/DifferentialExpression/run_DE_analysis.pl
@@ -390,10 +390,10 @@ sub run_edgeR_sample_pair {
     if ($num_rep_A > 1 && $num_rep_B > 1) {
         print $ofh "exp_study = estimateCommonDisp(exp_study)\n";
         print $ofh "exp_study = estimateTagwiseDisp(exp_study)\n";
-        print $ofh "et = exactTest(exp_study)\n";
+        print $ofh "et = exactTest(exp_study, pair=c("\"$sample_A\", \"$sample_B\"))\n";
     }
     else {
-        print $ofh "et = exactTest(exp_study, dispersion=$dispersion)\n";
+        print $ofh "et = exactTest(exp_study, pair=c("\"$sample_A\", \"$sample_B\"), dispersion=$dispersion)\n";
     }
     print $ofh "tTags = topTags(et,n=NULL)\n";
     print $ofh "write.table(tTags, file=\'$output_prefix.edgeR.DE_results\', sep='\t', quote=F, row.names=T)\n";

--- a/Analysis/DifferentialExpression/run_DE_analysis.pl
+++ b/Analysis/DifferentialExpression/run_DE_analysis.pl
@@ -390,10 +390,10 @@ sub run_edgeR_sample_pair {
     if ($num_rep_A > 1 && $num_rep_B > 1) {
         print $ofh "exp_study = estimateCommonDisp(exp_study)\n";
         print $ofh "exp_study = estimateTagwiseDisp(exp_study)\n";
-        print $ofh "et = exactTest(exp_study, pair=c("\"$sample_A\", \"$sample_B\"))\n";
+        print $ofh "et = exactTest(exp_study, pair=c(\"$sample_A\", \"$sample_B\"))\n";
     }
     else {
-        print $ofh "et = exactTest(exp_study, pair=c("\"$sample_A\", \"$sample_B\"), dispersion=$dispersion)\n";
+        print $ofh "et = exactTest(exp_study, pair=c(\"$sample_A\", \"$sample_B\"), dispersion=$dispersion)\n";
     }
     print $ofh "tTags = topTags(et,n=NULL)\n";
     print $ofh "write.table(tTags, file=\'$output_prefix.edgeR.DE_results\', sep='\t', quote=F, row.names=T)\n";


### PR DESCRIPTION
trinity is not using the exactTest method in Analysis/DifferentialExpression/run_DE_analysis.pl correctly, which defaults to the levels of the grouping factor for picking sample A and B (aka ctrl and treatment). However, by doing so the order depends on the alphabetical order of the 2 condition names since R is resorting levels when creating the factor “conditions”


See small knitr example
https://dl.dropboxusercontent.com/u/113630701/trinity_edger_problem.html