### PR TITLE
Processing the jobid from qstat using the same regex as qsub output

### DIFF
--- a/PerlLib/HPC/PBS_handler.pm
+++ b/PerlLib/HPC/PBS_handler.pm
@@ -83,8 +83,11 @@ sub job_running_or_pending_on_grid {
 
     foreach my $line (split(/\n/, $response)) {
         my @x = split(/\s+/, $line);
-
-        if ($x[0] eq $job_id) {
+	my $lcl_job_id = $x[0];
+	if ($x[0] =~ /(\d+)(\.[0-9a-zA-Z])*/) {
+	    $lcl_job_id = $1;
+	}
+        if ($lcl_job_id eq $job_id) {
             my $state = $x[4];
             
             $self->{job_id_to_submission_time}->{$job_id} = time();


### PR DESCRIPTION
Changed the job status checking code in PBS handler to account for the .pbs (in my case) extension to job id in qstat output. This fixes the jobid not found error that I've been encountering in our PBS cluster installation. I used the same regex that is used to filter the jobid out of the qsub output.