### PR TITLE
samtools_max_memory div by 2

### DIFF
--- a/Trinity
+++ b/Trinity
@@ -1554,7 +1554,7 @@ sub run_chrysalis {
             $pipeliner->add_commands( new Command($cmd, "$iworm_min100_fa_file.bowtie_build.ok"));
 
             my $bowtie_sam_file = "$chrysalis_output_dir/iworm.bowtie.nameSorted.bam";
-	    my $samtools_max_memory = int($jellyfish_ram/$CPU);
+	    my $samtools_max_memory = int($jellyfish_ram/($CPU*2));
             if ($long_reads){
             	$cmd = "bash -c \" set -o pipefail;bowtie2 --local -a --threads $CPU -f $iworm_min100_fa_file $bowtie_reads_fa  | samtools view $PARALLEL_SAMTOOLS_SORT_TOKEN -F4 -Sb - | samtools sort -m $samtools_max_memory $PARALLEL_SAMTOOLS_SORT_TOKEN -no - - > $bowtie_sam_file\" ";  
             }


### PR DESCRIPTION
A test I did showed that samtools sort (1.2) was using more than $samtools_max_memory * $CPU  (over 470g [as in top] being used for a $jellyfish_ram=250G and $CPU=35 ).
setting it by half may be enough.
Looking safe by now. The test is running fine.