### PR TITLE
run_GOseq.pl: Remove the --vanilla option

### DIFF
--- a/Analysis/DifferentialExpression/run_GOseq.pl
+++ b/Analysis/DifferentialExpression/run_GOseq.pl
@@ -155,7 +155,7 @@ main: {
     
     close $ofh;
 
-    my $cmd = "R --vanilla -q < $Rscript";
+    my $cmd = "R --no-save --no-restore --no-site-file --no-init-file --quiet < $Rscript";
     my $ret = system($cmd);
     if ($ret) {
         die "Error, cmd: $cmd died with ret $ret";


### PR DESCRIPTION
The `--vanilla` option includes the `--no-environ` option which forces R not to read user's environment files therefore libraries installed in custom locations won't be loaded.
Since `--vanilla` option is just a combination of `--no-save`, `--no-restore`, `--no-site-file`, `--no-init-file` and `--no-environ`, this commit removes the `--no-environ` option & includes the rest.

Closes #90.