### PR TITLE
Chrysalis: add GCC 6 support to Makefile

### DIFF
--- a/Chrysalis/Makefile
+++ b/Chrysalis/Makefile
@@ -306,6 +306,9 @@ ifeq ($(COMPILER),g++)
   ifeq ($(GPP_MAJOR_VERSION),5)
        SYS_INCS        = -iquote . $(XERCES_INC)
   endif
+  ifeq ($(GPP_MAJOR_VERSION),6)
+       SYS_INCS        = -iquote . $(XERCES_INC)
+  endif
 endif
 
 # Linking control (e.g. to link templates):


### PR DESCRIPTION
Without this change, trinity fails to compile because Chrysalis can't
find headers that it needs.