### PR TITLE
update CMD to make samtools work well in a stream

### DIFF
--- a/Trinity
+++ b/Trinity
@@ -1560,10 +1560,10 @@ sub run_chrysalis {
             my $bowtie_sam_file = "$chrysalis_output_dir/iworm.bowtie.nameSorted.bam";
             my $samtools_max_memory = int($jellyfish_ram/($CPU*2));
             if ($long_reads){
-            	$cmd = "bash -c \" set -o pipefail;bowtie2 --local -a --threads $CPU -f $iworm_min100_fa_file $bowtie_reads_fa  | samtools view $PARALLEL_SAMTOOLS_SORT_TOKEN -F4 -Sb - | samtools sort -m $samtools_max_memory $PARALLEL_SAMTOOLS_SORT_TOKEN -no - - > $bowtie_sam_file\" ";  
+            	$cmd = "bash -c \" set -o pipefail;bowtie2 --local -a --threads $CPU -f $iworm_min100_fa_file $bowtie_reads_fa  | samtools view - $PARALLEL_SAMTOOLS_SORT_TOKEN -F4 -Sb | samtools sort - -m $samtools_max_memory $PARALLEL_SAMTOOLS_SORT_TOKEN -no - > $bowtie_sam_file\" ";  # the '-' as the standard input (stdin) in origin perl program cannot work well in CentOS
             }
             else{
-            	$cmd = "bash -c \" set -o pipefail; bowtie -a -m 20 --best --strata --threads $CPU  --chunkmbs 512 -q -S -f $iworm_min100_fa_file $bowtie_reads_fa  | samtools view $PARALLEL_SAMTOOLS_SORT_TOKEN -F4 -Sb - | samtools sort -m $samtools_max_memory $PARALLEL_SAMTOOLS_SORT_TOKEN -no - - > $bowtie_sam_file\" ";
+            	$cmd = "bash -c \" set -o pipefail; bowtie -a -m 20 --best --strata --threads $CPU  --chunkmbs 512 -q -S -f $iworm_min100_fa_file $bowtie_reads_fa  | samtools view - $PARALLEL_SAMTOOLS_SORT_TOKEN -F4 -Sb | samtools sort - -m $samtools_max_memory $PARALLEL_SAMTOOLS_SORT_TOKEN -no - > $bowtie_sam_file\" ";
             }            
             
             $pipeliner->add_commands( new Command($cmd, "$bowtie_sam_file.ok"));


### PR DESCRIPTION
Line 1563 and 1566, the samtools command cannot work in CentOS, because the  '-' as the standard input (stdin)  was put at the wrong position.