### PR TITLE
Attack of the Zombies

### DIFF
--- a/Trinity
+++ b/Trinity
@@ -1236,7 +1236,7 @@ main: {
         }
         
         if ($MKDIR_OUTDIR_FLAG && basename($output_directory) =~ /trinity/i) { # ensure outdirectory as trinity in the name, just to be sure we dont delete something non-trinity related!!!
-            system("rm -rf $output_directory &"); # ignore filesystem errors on failed cleanup
+            system("nohup rm -rf $output_directory &! > /dev/null"); # ignore filesystem errors on failed cleanup
         }
         else {
             print STDERR "WARNING, cannot remove output directory $output_directory, since not created in this run. (safety precaution)\n";

--- a/Trinity
+++ b/Trinity
@@ -1236,7 +1236,8 @@ main: {
         }
         
         if ($MKDIR_OUTDIR_FLAG && basename($output_directory) =~ /trinity/i) { # ensure outdirectory as trinity in the name, just to be sure we dont delete something non-trinity related!!!
-            system("nohup rm -rf $output_directory &! > /dev/null"); # ignore filesystem errors on failed cleanup
+            #system("rm -rf $output_directory &! > /dev/null"); # ignore filesystem errors on failed cleanup
+            system("rm -rf $output_directory");
         }
         else {
             print STDERR "WARNING, cannot remove output directory $output_directory, since not created in this run. (safety precaution)\n";

--- a/Trinity
+++ b/Trinity
@@ -1236,7 +1236,6 @@ main: {
         }
         
         if ($MKDIR_OUTDIR_FLAG && basename($output_directory) =~ /trinity/i) { # ensure outdirectory as trinity in the name, just to be sure we dont delete something non-trinity related!!!
-            #system("rm -rf $output_directory &! > /dev/null"); # ignore filesystem errors on failed cleanup
             system("rm -rf $output_directory");
         }
         else {


### PR DESCRIPTION
I've been using the Trinity Assembler for over a month now, and I notice that my assemblies would often fail during the `Trinity Phase 2: Assembling Clusters of Reads` phase.  For example, the current assembly I'm building now has 267,238 commands.  I'm using mostly defaults, so these commands are cleaning up their directory with the [following](https://github.com/trinityrnaseq/trinityrnaseq/blob/master/Trinity#L1239) system call; Trinity is shunting the `rm(1)` to the background and then [promptly](https://github.com/trinityrnaseq/trinityrnaseq/blob/master/Trinity#L1269) exiting.  Do you see the problem?  The parent process is not there to call `wait(2)`, and the `rm(1)` process remains in the process table until the entire Trinity process finishes.  This quickly exhausts the process table, and creates a lot of errors that look like out of memory issues (but they're not, it's just that the OS can't `fork(2)` anymore).  The solution is simple, don't background the `rm(1)` process.  You will properly reap the process, you won't exhaust your process table, and your assemblies will actually finish.  There is absolutely no downside to keeping the `rm(1)` process in the foreground, because it's the last thing this child process executes before finally exiting itself.  Your assemblies will also finish a lot quicker, because the Linux scheduler is only dealing with thousands or processes, instead of hundreds-of-thousands.