### PR TITLE
Minor bug on running jellyfish with small datasets

### DIFF
--- a/Trinity
+++ b/Trinity
@@ -2158,7 +2158,7 @@ sub run_inchworm {
         my $jelly_hash_size = int( ($jellyfish_ram - $read_file_size)/7); # decided upon by Rick Westerman
         
         
-        if ($jelly_hash_size < 100e6) {
+        if ($jelly_hash_size < 100e6 || $read_file_size < 5e9) {
             $jelly_hash_size = 100e6; # seems reasonable for a min hash size as 100M
         }
         


### PR DESCRIPTION
I was doing the iterative assembly by adding RNAseq samples one by one for trinity input to see how the resulted number of transcripts and their lengths are accumulated. It was turned out that for small data input (say, less than 5Gb of filtered fasta file) the estimated "-s" parameter for jellyfish is too large to fit into RAM of my cluster node (64Gb available in my settings) resulting in trinity termination with jellyfish malloc error. This simple sanity check overcomes the problem. There could be a better and more general solution though.