### PR TITLE
Fixed partitioned commands path

### DIFF
--- a/Trinity
+++ b/Trinity
@@ -3040,7 +3040,7 @@ sub run_genome_guided_Trinity {
 
 ####
 sub run_partitioned_cmds {
-    my ($cmds_file) = @_;
+    my ($cmds_file) = "$output_directory/@_";
     
     
     print STDERR "\n\n";


### PR DESCRIPTION
When someone try to run Trinity in a compute farm, it will try to dispatch the partitioned commands trying to locate those in the current directory instead of the output directory (trinity_out_dir by default), and finally it will fail. Here is an example of the output without the change using "HPC GridRunner" for leverage the commands:

```
--------------------------------------------------------------------------------
------------ Trinity Phase 2: Assembling Clusters of Reads ---------------------
--------------------------------------------------------------------------------



	*** Dispatching parallel commands to the compute farm:
Thursday, November 24, 2016: 20:00:48	CMD: hpc_cmds_GridRunner.pl --grid_conf SLURM.conf recursive_trinity.cmds

################################################################
# Required:
#
#  -c <string>        file containing list of commands
#  --grid_conf|G <string>   grid config file
#
# Optional:
#  
#  --parafly          if any grid commands fail on the grid, try rerunning
#                     them locally using ParaFly (second chance to succeed).
#                     This requires that ParaFly be installed and in your PATH
#                     Get ParaFly here: http://parafly.sourceforge.net/
#
####################################################################


Error, cmd: hpc_cmds_GridRunner.pl --grid_conf SLURM.conf recursive_trinity.cmds died with ret 65280 at _TRINITY_PATH_ line 2427.
Trinity run failed. Must investigate error above.
```