### PR TITLE
Remove '.gz' suffixes from the test run

### DIFF
--- a/sample_data/test_Trinity_Assembly/runMe.sh
+++ b/sample_data/test_Trinity_Assembly/runMe.sh
@@ -16,8 +16,8 @@ fi
 #######################################################
 
 ../../Trinity --seqType fq --max_memory 2G \
-              --left reads.left.fq.gz \
-              --right reads.right.fq.gz \
+              --left reads.left.fq \
+              --right reads.right.fq \
               --SS_lib_type RF \
               --CPU 4 $*
 


### PR DESCRIPTION
The initial script tasks unpack the gzipped fastq files, but then the actual run references the original gzipped files.  Presumably, the unzipped files should be used?