### PR TITLE
Optimize bowtie2 / samtools sort pipelines

### DIFF
--- a/Trinity
+++ b/Trinity
@@ -1768,7 +1768,7 @@ sub run_chrysalis {
             my $bowtie_sam_file = "$chrysalis_output_dir/iworm.bowtie.nameSorted.bam";
             my $samtools_max_memory = int($jellyfish_ram/($CPU*2));
 
-            $cmd = "bash -c \" set -o pipefail;bowtie2 --local -k 2 --threads $CPU -f --score-min G,46,0 -x $iworm_min100_fa_file $bowtie_reads_fa  | samtools view $PARALLEL_SAMTOOLS_SORT_TOKEN -F4 -Sb - | samtools sort -m $samtools_max_memory $PARALLEL_SAMTOOLS_SORT_TOKEN -no - - > $bowtie_sam_file\" ";  
+            $cmd = "bash -c \" set -o pipefail;bowtie2 --local -k 2 --threads $CPU --no-unal -f --score-min G,46,0 -x $iworm_min100_fa_file $bowtie_reads_fa  | samtools sort -m $samtools_max_memory $PARALLEL_SAMTOOLS_SORT_TOKEN -no - - > $bowtie_sam_file\" ";
                         
             $pipeliner->add_commands( new Command($cmd, "$bowtie_sam_file.ok"));
             

--- a/util/support_scripts/bowtie2_wrapper.pl
+++ b/util/support_scripts/bowtie2_wrapper.pl
@@ -226,13 +226,13 @@ main: {
     my $cmd;
     if ($left_file && $right_file) {
 
-        $cmd = "bash -c \"set -o pipefail; bowtie2 --local -k $num_top_hits --threads $CPU $format -x $max_dist_between_pairs -x $target_db -1 $left_file -2 $right_file | samtools view -F4 -Sb - | samtools sort -o - - > $output_file\" ";
+        $cmd = "bash -c \"set -o pipefail; bowtie2 --local -k $num_top_hits --threads $CPU --no-unal $format -x $max_dist_between_pairs -x $target_db -1 $left_file -2 $right_file | samtools sort -@ $CPU -o - - > $output_file\" ";
         
 
     }
     else {
         
-        $cmd = "bash -c \"set -o pipefail; bowtie2 --local -k $num_top_hits --threads $CPU $format -x $target_db -U $single_file | samtools view -F4 -Sb - | samtools sort -o - - > $output_file\" ";
+        $cmd = "bash -c \"set -o pipefail; bowtie2 --local -k $num_top_hits --threads $CPU --no-unal $format -x $target_db -U $single_file | samtools sort -@ $CPU -o - - > $output_file\" ";
         
     }
     


### PR DESCRIPTION
A colleague experienced very long run time (on the order of days) with a large metatranscriptomic data set in the following stage of the Trinity pipeline:

```
Running cmd: bash -c " set -o pipefail; bowtie -a -m 20 --best --strata --threads 60  --chunkmbs 512 -q -S -f /path/to/trinity_output/chrysalis/inchworm.K25.L25.fa.min100 both.fa  | samtools view -@ 60 -F4 -Sb - | samtools sort -@ 60 -no - - > /path/to/trinity_output/chrysalis/iworm.bowtie.nameSorted.bam"  2>/dev/null
```

While `samtools sort` is almost certainly the primary bottleneck, the `samtools view` is likely a contributing factor. The `samtools view` process reads SAM emitted by `bowtie2`, filters unmapped reads (`-F4`), and encodes the results as compressed BAM (`-b`) using multi-threaded compression. The `samtools sort` process reads the compressed BAM, performs decompression _with a single-thread_ (as of HTSlib 1.3.2), and performs sorting and compression with multiple threads.

An alternative approach suggested by this pull request is to add the "--no-unal" option to bowtie2 to avoid emitting unmapped reads, obviating the need for `samtools view` to filter unmapped reads, and let `samtools sort` consume the SAM emitted by bowtie2 directly. Some basic benchmarking (on a somewhat-old system) appeared to indicate that `samtools sort -@ 8` (from SAMtools 1.3.1) is faster when parsing SAM instead of decoding compressed BAM.

This patch also passes through the user-specified number of threads to `samtools sort` in util/support_scripts/bowtie2_wrapper.pl (which was previously invoked in its default single-threaded mode). This has the side effect of using the SAMtools default of up to 768M of memory per extra thread (rather than computing an amount based on the amount specified for Jellyfish, like the main Trinity driver script does). While it seems likely that systems running Trinity will have >> 1 GB of memory per core, it may be desirable to optimize the `samtools sort` max memory at least for consistency with the main Trinity script.

One place where this change was not made is in Chrysalis/analysis/Chrysalis.cc, which has code that still invokes the original bowtie (not bowtie2---is this intended?), as bowtie 1.x lacks the lacks the --no-unal option.