### PR TITLE
PtR : fix memory issue and distance matrix size

### DIFF
--- a/Analysis/DifferentialExpression/PtR
+++ b/Analysis/DifferentialExpression/PtR
@@ -567,6 +567,7 @@ main: {
     #$Rscript .= "library(gplots)\n";
     $Rscript .= "library(Biobase)\n";
     $Rscript .= "library(qvalue)\n";
+    $Rscript .= "library(fastcluster)\n";
 
     $Rscript .= "options(stringsAsFactors = FALSE)\n";
     

--- a/Analysis/DifferentialExpression/cut_tree_into_clusters.pl
+++ b/Analysis/DifferentialExpression/cut_tree_into_clusters.pl
@@ -87,6 +87,7 @@ main: {
     print $ofh "library(cluster)\n";
     #print $ofh "library(gplots)\n";
     print $ofh "library(Biobase)\n";
+    print $ofh "library(fastcluster)\n";
     print $ofh "source(\"$FindBin::RealBin/R/heatmap.3.R\")\n";
     
     print $ofh "load(\"$R_data_file\")\n";

--- a/Analysis/DifferentialExpression/define_clusters_by_cutting_tree.pl
+++ b/Analysis/DifferentialExpression/define_clusters_by_cutting_tree.pl
@@ -88,6 +88,7 @@ main: {
     print $ofh "library(cluster)\n";
     #print $ofh "library(gplots)\n";
     print $ofh "library(Biobase)\n";
+    print $ofh "library(fastcluster)\n";
     print $ofh "source(\"$FindBin::RealBin/R/heatmap.3.R\")\n";
     
     print $ofh "load(\"$R_data_file\")\n";


### PR DESCRIPTION
This modification allows to solve the following issue with PtR on huge data:

```
> hc_genes = hclust(gene_dist, method='complete')
Error in hclust(gene_dist, method = "complete") : 
  size cannot be NA nor exceed 65536
Execution halted
```

It also greatly reduces RAM consumption from 469 Go to less than 5 Go on our test files.
Results obtained on our test sample are the same with cluster and fastcluster.

The only drawback is that fastcluster must be installed in R
