### PR TITLE
Fix build of Chrysalis on localized systems

### DIFF
--- a/Chrysalis/Makefile
+++ b/Chrysalis/Makefile
@@ -51,7 +51,7 @@
 # DEFINE GENERAL VARIABLES
 ##############################################################################
 
-DATE = $(shell date)
+DATE = $(shell date --rfc-3339=seconds)
 BUILD_DATETIME ?= $(DATE)  # allow for overrides to enable reproducible builds
 OS_NAME = $(shell uname -s)
 NODE_NAME = $(shell uname -n)


### PR DESCRIPTION
The Chrysalis makefile passes a compile timestamp to the compiler, however currently it does not standardize said timestamp.

Under certain localizations this leads to errors compiling due to
mismatched quotes, the solution is that if a timestamp is already
being taken it should always be a standardized format and not a
localized format.