### PR TITLE
Add .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.o
+*.swp
+*~
+/Chrysalis/bin
+/Chrysalis/build
+/Inchworm/bin
+/Inchworm/build


### PR DESCRIPTION
I would like to send pull-requst to add `.gitignore` file.
Because ...

Clear files.

```
$ git clean -fdx
```

```
$ make
$ make plugins
```

Then I saw below untracked files.
These files make me hard to contribute.
And I think it is safety to add ignored files to the file explicitly if we do not want to register to the repository.

```
$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

  Chrysalis/bin/
  Chrysalis/build/
  Inchworm/bin/
  Inchworm/build/
  trinity-plugins/BIN/ParaFly
  trinity-plugins/BIN/seqtk-trinity
  trinity-plugins/COLLECTL/collectl
  trinity-plugins/COLLECTL/collectl-4.1.0/
  trinity-plugins/ParaFly-0.1.0/
  trinity-plugins/Trimmomatic
  trinity-plugins/seqtk-trinity-0.0.2/
  trinity-plugins/slclust/bin/slclust
  trinity-plugins/slclust/src/cmd_line_opts.o
  trinity-plugins/slclust/src/graph.o
  trinity-plugins/slclust/src/graphnode.o
  trinity-plugins/slclust/src/slcluster.o
```

In this pull-request, I only added obvious files for ignorance.
