### PR TITLE
Add Travis CI build status and Bioconda link badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 trinityrnaseq
 =============
 
+[![Build Status](https://travis-ci.org/trinityrnaseq/trinityrnaseq.svg?branch=master)](https://travis-ci.org/trinityrnaseq/trinityrnaseq)
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](https://bioconda.github.io/recipes/trinity/README.html)
+
 Trinity RNA-Seq de novo transcriptome assembly see the main webpage [http://trinityrnaseq.github.io](http://trinityrnaseq.github.io)


### PR DESCRIPTION
I added Travis CI build status and Bioconda link badge to README.md.

You can check the modified RAEDME.md here.
https://github.com/junaruga/trinityrnaseq/blob/feature/badge-image/README.md

About the Travis CI badge, I picked up from the Travis URL clicking "build passing" icon.
https://travis-ci.org/trinityrnaseq/trinityrnaseq

I also referred salmon's README.md about bioconda badge.
https://github.com/COMBINE-lab/salmon/blob/master/README.md
And python about the badge position.
https://github.com/python/cpython/blob/master/README.rst
