### PR TITLE
Add clang test cases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 git:
   depth: 1
 language: generic
+# Custom definitions
+.conditions:
+  if: &secondary type = cron OR env(SECONDARY) = true
 matrix:
   include:
     # http://www.cpan.org/src/
@@ -11,9 +14,6 @@ matrix:
     - language: perl
       perl: "5.26-shrplib"
       env: CC=gcc-8 CXX=g++-8
-    # https://docs.travis-ci.com/user/languages/cpp/
-    - language: cpp
-      compiler: clang
     # https://docs.travis-ci.com/user/languages/java/
     - language: java
       jdk: oraclejdk9
@@ -21,22 +21,50 @@ matrix:
     # https://docs.travis-ci.com/user/languages/python/
     - language: python
       python: "3.6"
+    - language: generic
+      env: CC=clang-3.9 CXX=clang++-3.9 LDFLAGS="-fopenmp=libiomp5"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.9
+          packages:
+            - clang-3.9
+      if: *secondary
+    - language: generic
+      # Open MP support is available from clang-3.7.
+      env: CC=clang-3.7 CXX=clang++-3.7 LDFLAGS="-fopenmp=libiomp5"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+      if: *secondary
     # Test old version of the dependency packages.
     - language: perl
       perl: "5.18-shrplib"
       env: BOWTIE2_VERSION=2.2.6
+      if: *secondary
     # https://docs.travis-ci.com/user/reference/osx
-    - os: osx
-      language: cpp
-      # Do not have to set "compiler: gcc" as it is actually clang on osx.
-      compiler: clang
     - os: osx
       osx_image: xcode9.4
       env: CC=gcc-8 CXX=g++-8
+    - os: osx
+      osx_image: xcode9.4
+      # "clang++" installed by llvm@3.9 instead of "clang++-3.9".
+      env: CC=clang-3.9 CXX=clang++
+      if: *secondary
+    - os: osx
+      osx_image: xcode9.4
+      env: CC=clang-3.7 CXX=clang++-3.7
+      if: *secondary
   allow_failures:
-    - language: cpp
-      compiler: clang
     - env: BOWTIE2_VERSION=2.2.6
+    - env: CC=clang-3.7 CXX=clang++-3.7 LDFLAGS="-fopenmp=libiomp5"
+    - os: osx
+      env: CC=clang-3.7 CXX=clang++-3.7
   fast_finish: true
 install:
   - |
@@ -56,8 +84,13 @@ install:
         echo "Installing ${CXX}."
         sudo apt-get install -qq "${CXX}"
       fi
+      if [[ "${CC}" =~ clang- ]]; then
+        echo "Installing ${CC}."
+        sudo apt-get install -qq "${CC}" libiomp-dev
+      fi
     else
       # osx
+      export HOMEBREW_NO_AUTO_UPDATE=1
       if [[ "${CC}" =~ gcc- ]]; then
         # Update command line tool to avoid an error:
         # "_stdio.h: No such file or directory", when building samtools.
@@ -70,6 +103,16 @@ install:
         CC_PKG="$(echo "${CC}" | sed -e 's/-/@/')"
         echo "Installing ${CC_PKG}."
         brew install "${CC_PKG}"
+      fi
+      if [[ "${CC}" =~ clang- ]]; then
+        echo "Installing ${CC}."
+        CC_VERSION=$(echo "${CC}" | sed -e 's/^clang-//')
+        brew install "llvm@${CC_VERSION}"
+        brew install libomp
+        CC_PREFIX=$(brew --prefix "llvm@${CC_VERSION}")
+        export PATH="${CC_PREFIX}/bin:$PATH"
+        export LDFLAGS="-L${CC_PREFIX}/lib -Wl,-rpath,${CC_PREFIX}/lib"
+        export CPPFLAGS="-I${CC_PREFIX}/include"
       fi
     fi
 
@@ -93,7 +136,7 @@ install:
   - pushd samtools-1.9
   - autoheader
   - autoconf -Wno-syntax
-  - ./configure
+  - ./configure || (cat config.log; false)
   - make
   - sudo make install
   - popd
@@ -118,7 +161,7 @@ install:
   - wget https://github.com/gmarcais/Jellyfish/releases/download/v${JELLYFISH_VERSION}/jellyfish-${JELLYFISH_VERSION}.tar.gz
   - tar xzf jellyfish-${JELLYFISH_VERSION}.tar.gz
   - pushd jellyfish-${JELLYFISH_VERSION}
-  - ./configure
+  - ./configure || (cat config.log; false)
   - make
   - sudo make install
   - popd


### PR DESCRIPTION
This fixes https://github.com/trinityrnaseq/trinityrnaseq/issues/551 .

I added and updated clang tests.
Here is the result on my repository.
https://travis-ci.org/junaruga/trinityrnaseq/builds/441841696
You can see added some cases.
But in this PR, you only see 4 test case that is same with current master branch.
The reason is because I added "conditional" jobs for clang test cases. [1]

I think running all the test case every time is not practical.
But in other words, we want to see regularly check supported cases.

## Use case

Usually only 4 cases are run on Travis CI such as pull-request, and pushing to branches.
If Travis is run on cron mode "or" environment variable `SECONDARY` is set as `true` from Travis Setting page, other jobs are executed too.
So, I would recommend to run test on Travis cron mode daily too.

![screenshot-travis-ci org-2018 10 15-21-54-16](https://user-images.githubusercontent.com/121989/46976435-ca8c5b00-d0c9-11e8-937a-9957b2254d88.png)

## Result of clang test cases

As we know clang >= 3.7 supports OpenMP.

- linux and clang-3.9: ok
- osx and clang-3.9: ok
- linux and clang-3.7: Segmentation fault (core dumped)
- osx and clang-3.7: below error.

```
/Users/travis/build/junaruga/trinityrnaseq/Inchworm/src/fastaToKmerCoverageStats.cpp
:89:13: error: use of undeclared identifier 'omp_set_num_threads'
            omp_set_num_threads(num_threads);
            ^
```

Finally I would introduce useful example to add C/C++ test cases on various environment. [4]

[1] Travis conditions: https://docs.travis-ci.com/user/conditions-v1
[2] YAML anchor and reference: https://en.wikipedia.org/wiki/YAML#Advanced_components
[3] YAML 1.1 is used for Travis: http://yaml.org/spec/1.1/
[4] https://github.com/Microsoft/GSL/blob/master/.travis.yml