### PR TITLE
.travis.yml: Fix osx gcc-8 case.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,11 +95,8 @@ install:
         # Update command line tool to avoid an error:
         # "_stdio.h: No such file or directory", when building samtools.
         softwareupdate --list
-        softwareupdate --install "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"
+        softwareupdate --install "Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.1"
 
-        # Uninstall oclint to install gcc on OSX.
-        # https://github.com/travis-ci/travis-ci/issues/8826
-        brew cask uninstall oclint
         CC_PKG="$(echo "${CC}" | sed -e 's/-/@/')"
         echo "Installing ${CC_PKG}."
         brew install "${CC_PKG}"


### PR DESCRIPTION
Hello. This fixes below current test failure on osx gcc-8.

https://travis-ci.org/trinityrnaseq/trinityrnaseq/jobs/457916661
> Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4: No such update
> No updates are available.
> Error: Cask 'oclint' is not installed.

By the way, please note that current logic in `- |` element of `.travis.yml` does not handle command error of `oftwareupdate --install ... ` and `brew cask uninstall oclint`.
In the `- |` element,  only last command's exit status is handled.