### PR TITLE
Change README build status image badge's branch from master to devel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 trinityrnaseq
 =============
 
-[![Build Status](https://travis-ci.org/trinityrnaseq/trinityrnaseq.svg?branch=master)](https://travis-ci.org/trinityrnaseq/trinityrnaseq)
+[![Build Status](https://travis-ci.org/trinityrnaseq/trinityrnaseq.svg?branch=devel)](https://travis-ci.org/trinityrnaseq/trinityrnaseq)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](https://bioconda.github.io/recipes/trinity/README.html)
 
 Trinity RNA-Seq de novo transcriptome assembly see the main webpage [http://trinityrnaseq.github.io](http://trinityrnaseq.github.io)


### PR DESCRIPTION
This PR is to change the branch to be showed as a build status image badge on `README.md`.

Modified README.
https://github.com/junaruga/trinityrnaseq/blob/feature/devel-readme-travis-branch/README.md

Because seeing Ruby and Rails, for Ruby "trunk" is used as a development branch, and it is used for the image badge branch. For Rails, "master" is used as a development branch, and it is used for the image badge branch.

Ruby
https://raw.githubusercontent.com/ruby/ruby/trunk/README.md
https://travis-ci.org/ruby/ruby.svg?branch=trunk

Ruby on Rails
https://raw.githubusercontent.com/rails/rails/master/README.md
https://travis-ci.org/rails/rails.svg?branch=master

So, in case of Trinity, using "devel" looks right choice.
