### PR TITLE
Update align_and_estimate_abundance.pl

### DIFF
--- a/util/align_and_estimate_abundance.pl
+++ b/util/align_and_estimate_abundance.pl
@@ -853,10 +853,10 @@ sub run_salmon {
         my $cmd;
         
         if ($salmon_idx_type eq 'quasi') {
-            $cmd = "salmon index -t $transcripts -i $salmon_index --type quasi -k $salmon_quasi_kmer_length -p $thread_count";
+            $cmd = "salmon index -t $transcripts --keepDuplicates -i $salmon_index --type quasi -k $salmon_quasi_kmer_length -p $thread_count";
         }
         elsif ($salmon_idx_type eq 'fmd') {
-            $cmd = "salmon index -t $transcripts -i $salmon_index --type fmd -p $thread_count";
+            $cmd = "salmon index -t $transcripts --keepDuplicates -i $salmon_index --type fmd -p $thread_count";
         }
         else {
             die "Error, not recognizing idx type: $salmon_idx_type";


### PR DESCRIPTION
I added the parameter --keepDuplicates to the index creation using salmon to fix the error: "Error, no TPM value specified for transcript...". The file Trinity.fasta.gene_trans_map contains also the duplicated transcripts that salmon filters during the index creation. 