### PR TITLE
Update Glimma.Trinity.Rscript

### DIFF
--- a/Analysis/DifferentialExpression/Glimma.Trinity.Rscript
+++ b/Analysis/DifferentialExpression/Glimma.Trinity.Rscript
@@ -27,11 +27,9 @@ DE_results_file = args$DE_results
 counts_matrix_file = args$counts_matrix
 samples_file = args$samples_file
 
-
-source("https://bioconductor.org/biocLite.R")
-biocLite("Glimma")
-biocLite("argparse")
-biocLite("edgeR")
+if (!requireNamespace("BiocManager", quietly = TRUE))
+    install.packages("BiocManager","Glimma","argparse","edgeR")
+BiocManager::install()
 
 library(edgeR)
 library(limma)


### PR DESCRIPTION
Corrected the installation of R packages that causes the error bellow:
"Error: With R version 3.5 or greater, install Bioconductor packages using BiocManager; see https://bioconductor.org/install
Execution halted"
see line 30 to 32